### PR TITLE
Implement Feedback from Foundry PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-disassembler"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Christian Koopmann <c.k.e.koopmann@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This library was inspired by the [pyevmasm](https://github.com/crytic/pyevmasm).
 # Installation
 `cargo add evm-disassembler`
 
+# Documentation
+See the API reference [here](https://docs.rs/evm-disassembler/).
+
 # Example
  ```rust
  use evm_disassembler::{disassemble_str, disassemble_bytes, format_operations};

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,9 +1,11 @@
 use crate::types::{Opcode, Operation};
 use eyre::Result;
-use std::collections::VecDeque;
 
-pub fn decode_operation(bytes: &mut VecDeque<u8>, cur_offset: u32) -> Result<(Operation, u32)> {
-    let encoded_opcode = bytes.pop_front().expect("Unexpected end of input");
+pub fn decode_operation(
+    bytes: &mut dyn ExactSizeIterator<Item = u8>,
+    cur_offset: u32,
+) -> Result<(Operation, u32)> {
+    let encoded_opcode = bytes.next().expect("Unexpected end of input");
     let num_bytes = match encoded_opcode {
         0x60..=0x7f => encoded_opcode - 0x5f,
         _ => 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 //! Output types for Operation and Opcode
 use eyre::{eyre, Result};
-use std::collections::VecDeque;
 use std::fmt;
 
 /// A single EVM operation
@@ -349,7 +348,11 @@ impl Operation {
     }
 
     /// Adds additional bytes to the operation (for PUSH instructions)
-    pub fn with_bytes(self, num_bytes: u8, bytes: &mut VecDeque<u8>) -> Result<Self> {
+    pub fn with_bytes(
+        self,
+        num_bytes: u8,
+        bytes: &mut dyn ExactSizeIterator<Item = u8>,
+    ) -> Result<Self> {
         if num_bytes == 0 {
             return Ok(self);
         }
@@ -363,7 +366,7 @@ impl Operation {
         Ok(Operation {
             opcode: self.opcode,
             offset: self.offset,
-            input: bytes.drain(0..num_bytes as usize).collect::<Vec<u8>>(),
+            input: bytes.take(num_bytes as usize).collect(),
         })
     }
 }


### PR DESCRIPTION
Implements changes suggested [here](https://github.com/foundry-rs/foundry/pull/4518#discussion_r1133244174). 

(Version bumped to `0.2.0` instead of `0.1.1` because return type of `format_operations` changed to `Result<String>`)