### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ Disassemble EVM bytecode into individual Opcodes and format into human readable 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eyre = "0.6.8"
+eyre = "0.6.12"
 hex = "0.4.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps the dependency to at least 0.6.12 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0021.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)