### PR TITLE
feat: Add Fusaka opcodes (CLZ and EOF)

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4,15 +4,52 @@ use eyre::Result;
 pub fn decode_operation(
     bytes: &mut dyn ExactSizeIterator<Item = u8>,
     cur_offset: u32,
+    is_eof: bool,
 ) -> Result<(Operation, u32)> {
     let encoded_opcode = bytes.next().expect("Unexpected end of input");
-    let num_bytes = match encoded_opcode {
+
+    // Determine number of immediate bytes based on opcode
+    // EOF opcodes with immediates are only decoded in EOF containers
+    let num_bytes: u8 = match encoded_opcode {
+        // PUSH1-PUSH32
         0x60..=0x7f => encoded_opcode - 0x5f,
+        // EOF 2-byte immediates: DATALOADN, RJUMP, RJUMPI, CALLF, JUMPF
+        0xd1 | 0xe0 | 0xe1 | 0xe3 | 0xe5 if is_eof => 2,
+        // EOF 1-byte immediates: DUPN, SWAPN, EXCHANGE, EOFCREATE, TXCREATE, RETURNCONTRACT
+        0xe6 | 0xe7 | 0xe8 | 0xec | 0xed | 0xee if is_eof => 1,
+        // RJUMPV: variable length - 1 byte (max_index) + (max_index + 1) * 2 bytes
+        #[allow(clippy::len_zero)]
+        0xe2 if is_eof => {
+            if bytes.len() > 0 {
+                // Peek at max_index to calculate total immediate size
+                // We need to consume the max_index byte and include it in the immediate
+                let max_index = bytes.next().unwrap_or(0);
+                let jump_table_size = (max_index as u16 + 1) * 2;
+                // Return early with special handling for RJUMPV
+                let new_offset = cur_offset + 2 + jump_table_size as u32;
+                let opcode = Opcode::from_byte_eof(encoded_opcode);
+                let mut operation = Operation::new(opcode, cur_offset);
+                // Collect max_index + jump table bytes
+                let mut input = vec![max_index];
+                for _ in 0..jump_table_size {
+                    if let Some(b) = bytes.next() {
+                        input.push(b);
+                    }
+                }
+                operation.input = input;
+                return Ok((operation, new_offset));
+            }
+            0
+        }
         _ => 0,
     };
 
     let mut new_offset = cur_offset + 1;
-    let opcode = Opcode::from_byte(encoded_opcode);
+    let opcode = if is_eof {
+        Opcode::from_byte_eof(encoded_opcode)
+    } else {
+        Opcode::from_byte(encoded_opcode)
+    };
     let mut operation = Operation::new(opcode, cur_offset);
     if num_bytes > 0 {
         new_offset += num_bytes as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,10 @@ pub fn disassemble_str(input: &str) -> Result<Vec<Operation>> {
 /// Disassemble a vector of bytes into a vector of decoded Operations
 ///
 /// Will stop disassembling when it encounters a push instruction with a size greater than
-/// remaining bytes in the input
+/// remaining bytes in the input.
+///
+/// Automatically detects EOF containers (starting with 0xef00) and decodes EOF-specific
+/// opcodes only when appropriate.
 ///
 /// # Arguments
 /// - `bytes` - A vector of bytes representing the encoded bytecode
@@ -74,12 +77,15 @@ pub fn disassemble_str(input: &str) -> Result<Vec<Operation>> {
 /// let instructions_from_bytes = disassemble_bytes(bytes).unwrap();
 /// ```
 pub fn disassemble_bytes(bytes: Vec<u8>) -> Result<Vec<Operation>> {
+    // Detect EOF container: starts with 0xef00
+    let is_eof = bytes.len() >= 2 && bytes[0] == 0xef && bytes[1] == 0x00;
+
     let mut operations = Vec::new();
     let mut new_operation: Operation;
     let mut offset = 0;
     let mut bytes_iter = bytes.into_iter();
     while bytes_iter.len() > 0 {
-        (new_operation, offset) = match decode_operation(&mut bytes_iter, offset) {
+        (new_operation, offset) = match decode_operation(&mut bytes_iter, offset, is_eof) {
             Ok((operation, new_offset)) => (operation, new_offset),
             Err(e) => {
                 println!("Stop decoding at offset {offset} due to error : {e}");
@@ -211,5 +217,118 @@ mod tests {
                 Operation::new(Opcode::STOP, 1),
             ]
         );
+    }
+
+    // EOF container tests
+    // EOF format: ef0001 [header] [types] [code] [data]
+    // Header: 01 XXXX (type section) 02 YYYY ZZZZ (code section) 04 WWWW (data section) 00 (terminator)
+
+    #[rstest]
+    fn test_eof_detection() {
+        // This should be detected as EOF (starts with ef00)
+        // Minimal EOF: ef0001 01 0004 02 0001 0001 04 0000 00 [types: 00000000] [code: 00]
+        let eof_bytecode = "ef00010100040200010001040000000000000000";
+        let ops = disassemble_str(eof_bytecode).expect("Should decode EOF");
+        // In EOF mode, the header bytes are decoded as opcodes (some will be INVALID)
+        // The important thing is it doesn't crash
+        assert!(!ops.is_empty());
+    }
+
+    #[rstest]
+    fn test_eof_with_rjump() {
+        // EOF with RJUMP instruction in code section
+        // Header: ef0001 01 0004 02 0001 0003 04 0000 00
+        // Types: 00 80 00 01 (0 inputs, non-returning, max stack 1)
+        // Code: e0 00 00 (RJUMP with offset 0)
+        let eof_bytecode = "ef000101000402000100030400000000800001e00000";
+        let ops = disassemble_str(eof_bytecode).expect("Should decode EOF");
+        let formatted = format_operations(ops).unwrap();
+        println!("EOF with RJUMP:\n{}", formatted);
+        // Should contain RJUMP since this is EOF format
+        assert!(
+            formatted.contains("RJUMP"),
+            "Should decode RJUMP in EOF container"
+        );
+    }
+
+    #[rstest]
+    fn test_eof_with_callf() {
+        // EOF with CALLF and RETF
+        // Header: ef0001 01 0008 02 0002 0003 0001 04 0000 00
+        // Types section (8 bytes for 2 functions):
+        //   00 80 00 01 - func 0: 0 inputs, non-returning, max stack 1
+        //   00 00 00 00 - func 1: 0 inputs, 0 outputs, max stack 0
+        // Code section 0 (3 bytes): e3 0001 - CALLF 1
+        // Code section 1 (1 byte): e4 - RETF
+        let eof_bytecode = "ef00010100080200020003000104000000008000010000000000e30001e4";
+        let ops = disassemble_str(eof_bytecode).expect("Should decode EOF");
+        let formatted = format_operations(ops).unwrap();
+        println!("EOF with CALLF:\n{}", formatted);
+        assert!(
+            formatted.contains("CALLF"),
+            "Should decode CALLF in EOF container"
+        );
+    }
+
+    #[rstest]
+    fn test_legacy_bytecode_no_eof_opcodes() {
+        // Legacy bytecode containing byte 0xe0 should NOT decode as RJUMP
+        // This tests that EOF opcodes are only decoded in EOF containers
+        let legacy_bytecode = "60e0"; // PUSH1 0xe0
+        let ops = disassemble_str(legacy_bytecode).expect("Should decode legacy");
+        let formatted = format_operations(ops).unwrap();
+        println!("Legacy bytecode:\n{}", formatted);
+        // Should be PUSH1, not RJUMP
+        assert!(formatted.contains("PUSH1"), "Should decode as PUSH1");
+        assert!(
+            !formatted.contains("RJUMP"),
+            "Should NOT decode as RJUMP in legacy"
+        );
+    }
+
+    #[rstest]
+    fn test_legacy_with_eof_like_bytes() {
+        // Legacy bytecode with bytes that would be EOF opcodes if in EOF mode
+        // 0xe7 would be SWAPN in EOF, but should be INVALID in legacy
+        let legacy_bytecode = "e7";
+        let ops = disassemble_str(legacy_bytecode).expect("Should decode legacy");
+        assert_eq!(
+            ops[0].opcode,
+            Opcode::INVALID,
+            "0xe7 should be INVALID in legacy"
+        );
+    }
+
+    #[rstest]
+    fn test_real_eof_contract_from_solidity() {
+        // Real EOF bytecode compiled from Solidity with --evm-version osaka --eofVersion 1
+        // Contract: SimpleEOF with setValue, getValue, add functions
+        let eof = "ef000101009c020027004b0004000400030003000b00010006000d001c00020001000b00050007001c000c000800120003001b001c001d0003000200030007000500090003000f0001000a0001000f00050013001300080400430000800003010100020001000100800002008000020200000301010001020000020201000500800004020100020101000102010003020100020001000200800004010000020201000202010005010100020080000302020005008000040080000200010001010100020101000101010001000100010101000202010004010100010101000101010001020000030100000200800002020100030201000360806040526004361015e10003e500175f35e3000180632096525514e1002980633fa4f24514e1001c80635524107714e1000f63771602f714e10003e0ffcee50016e50014e5000fe5000960e01ce4604051e45f80fd5f80fd5f910312e10001e4e50004e4e300069052e4905f60208301920190e30007e434e10015366004e30005e3001ce30002809181e300080390f3e500031ce4e490600802e3000ae3000be454e3000ce45f5f90e3000de434e10015366004e30005e3000ee30002809181e300080390f3e5000380e3000603e10001e45f80fd90503580e30010e4602081830312e100065f01e30011e4e500045f01e434e10014366004e30012e30023e300028080e300130390f3e5000390604082820312e1000f805f8301e3001191602001e30011e4e5000434e10016366004e3001590e30026e30002809181e300080390f3e500035f80fd5fe45f1ce4e30019e3000be454e3001ae4e30018505fe3001be45f1be4905f1990e3001d91811916911617e4e4e30006e3001fe30006e4e490e30020e300218154e3001e9055e45fe30022e4634e487b7160e01b5f52601160045260245ffde3000690e300068101809111e10001e4e50024e3001850e30025e4";
+
+        let ops = disassemble_str(eof).expect("Should decode real EOF contract");
+        let formatted = format_operations(ops).unwrap();
+
+        println!("\n=== Real EOF Contract Disassembly ===");
+        println!("(Header bytes decoded as opcodes, code section follows)\n");
+
+        // Show lines containing EOF opcodes
+        println!("Lines containing EOF opcodes:");
+        for line in formatted.lines() {
+            if line.contains("RJUMP")
+                || line.contains("CALLF")
+                || line.contains("RETF")
+                || line.contains("JUMPF")
+                || line.contains("DATALOAD")
+            {
+                println!("{}", line);
+            }
+        }
+        println!();
+
+        // Verify EOF opcodes are present
+        assert!(formatted.contains("RJUMPI"), "Should contain RJUMPI");
+        assert!(formatted.contains("JUMPF"), "Should contain JUMPF");
+        assert!(formatted.contains("CALLF"), "Should contain CALLF");
+        assert!(formatted.contains("RETF"), "Should contain RETF");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub fn disassemble_bytes(bytes: Vec<u8>) -> Result<Vec<Operation>> {
 ///
 /// # Arguments
 /// - `operations` - A vector of decoded operations as returned by `disassemble_str` or
-/// `disassemble_bytes`
+///   `disassemble_bytes`
 ///
 /// # Examples
 /// ```rust

--- a/src/types.rs
+++ b/src/types.rs
@@ -158,6 +158,36 @@ pub enum Opcode {
     BLOBBASEFEE,
     BLOBHASH,
     CLZ,
+    // EOF Data Section (EIP-7480)
+    DATALOAD,
+    DATALOADN,
+    DATASIZE,
+    DATACOPY,
+    // EOF Static Jumps (EIP-4200)
+    RJUMP,
+    RJUMPI,
+    RJUMPV,
+    // EOF Functions (EIP-4750, EIP-6206)
+    CALLF,
+    RETF,
+    JUMPF,
+    // EOF Stack (EIP-663)
+    DUPN,
+    SWAPN,
+    EXCHANGE,
+    // EOF Type (EIP-7761)
+    EXTCODETYPE,
+    // EOF Contract Creation (EIP-7620, EIP-7873)
+    EOFCREATE,
+    TXCREATE,
+    RETURNCONTRACT,
+    // EOF Calls (EIP-7069)
+    RETURNDATALOAD,
+    EXTCALL,
+    EXTDELEGATECALL,
+    EXTSTATICCALL,
+    // Other (EIP-5920)
+    PAY,
 }
 
 impl Opcode {
@@ -314,6 +344,46 @@ impl Opcode {
             0xfd => Opcode::REVERT,
             0xff => Opcode::SELFDESTRUCT,
             _ => Opcode::INVALID,
+        }
+    }
+
+    /// Convert a byte into an Opcode (EOF-aware version)
+    ///
+    /// This version includes EOF opcodes and should only be used for EOF containers.
+    pub fn from_byte_eof(byte: u8) -> Opcode {
+        match byte {
+            // EOF Data Section (EIP-7480)
+            0xd0 => Opcode::DATALOAD,
+            0xd1 => Opcode::DATALOADN,
+            0xd2 => Opcode::DATASIZE,
+            0xd3 => Opcode::DATACOPY,
+            // EOF Static Jumps (EIP-4200)
+            0xe0 => Opcode::RJUMP,
+            0xe1 => Opcode::RJUMPI,
+            0xe2 => Opcode::RJUMPV,
+            // EOF Functions (EIP-4750, EIP-6206)
+            0xe3 => Opcode::CALLF,
+            0xe4 => Opcode::RETF,
+            0xe5 => Opcode::JUMPF,
+            // EOF Stack (EIP-663)
+            0xe6 => Opcode::DUPN,
+            0xe7 => Opcode::SWAPN,
+            0xe8 => Opcode::EXCHANGE,
+            // EOF Type (EIP-7761)
+            0xe9 => Opcode::EXTCODETYPE,
+            // EOF Contract Creation (EIP-7620, EIP-7873)
+            0xec => Opcode::EOFCREATE,
+            0xed => Opcode::TXCREATE,
+            0xee => Opcode::RETURNCONTRACT,
+            // EOF Calls (EIP-7069)
+            0xf7 => Opcode::RETURNDATALOAD,
+            0xf8 => Opcode::EXTCALL,
+            0xf9 => Opcode::EXTDELEGATECALL,
+            0xfb => Opcode::EXTSTATICCALL,
+            // Other (EIP-5920)
+            0xfc => Opcode::PAY,
+            // Fall back to legacy opcodes for non-EOF-specific bytes
+            _ => Self::from_byte(byte),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,6 +157,7 @@ pub enum Opcode {
     SELFDESTRUCT,
     BLOBBASEFEE,
     BLOBHASH,
+    CLZ,
 }
 
 impl Opcode {
@@ -189,6 +190,7 @@ impl Opcode {
             0x1b => Opcode::SHL,
             0x1c => Opcode::SHR,
             0x1d => Opcode::SAR,
+            0x1e => Opcode::CLZ,
             0x20 => Opcode::SHA3,
             0x30 => Opcode::ADDRESS,
             0x31 => Opcode::BALANCE,


### PR DESCRIPTION
## Summary

- Add CLZ opcode (0x1e) from EIP-7939 (Fusaka upgrade)
- Add 21 EOF opcodes from EIP-7692 with proper immediate argument handling
- EOF opcodes are only decoded within EOF containers (bytecode starting with `0xef00`) to maintain backward compatibility with legacy contracts

### New Opcodes

| Category | Opcodes |
|----------|---------|
| Fusaka | CLZ |
| Data section | DATALOAD, DATALOADN, DATASIZE, DATACOPY |
| Static jumps | RJUMP, RJUMPI, RJUMPV |
| Functions | CALLF, RETF, JUMPF |
| Stack ops | DUPN, SWAPN, EXCHANGE |
| Type check | EXTCODETYPE |
| Creation | EOFCREATE, TXCREATE, RETURNCONTRACT |
| Calls | RETURNDATALOAD, EXTCALL, EXTDELEGATECALL, EXTSTATICCALL |
| Other | PAY |

## Test plan

- [x] All existing tests pass
- [x] New EOF detection tests verify correct opcode decoding in EOF containers
- [x] Legacy bytecode tests verify EOF opcodes remain INVALID in non-EOF code
- [x] Clippy clean